### PR TITLE
parse: initially clean AST before type-checking

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Package struct {
-	Files   []*File
+	files   []*File
 	version string // TODO, type.
 }
 
@@ -22,8 +22,6 @@ type File struct {
 	Unresolved []*Ident
 	Src        NamedReader
 }
-
-type Node interface{}
 
 // maybe every node has positional information?
 type Stmt interface{}
@@ -102,7 +100,7 @@ func NewScope(outer *Scope) *Scope {
 type Object struct {
 	Kind ObjKind
 	Name string      // declared name
-	Decl interface{} // corresponding Field, XxxSpec, FuncDef, LabeledStmt, AssignStmt, Scope; or nil
+	Decl interface{} // corresponding Field, XxxSpec, FuncDecl, LabeledStmt, AssignStmt, Scope; or nil
 	Data interface{} // object-specific data; or nil
 	Type interface{} // placeholder for type information; may be nil
 }
@@ -183,10 +181,9 @@ type BasicLit struct {
 }
 
 type BlockStmt struct {
-	Comments *RelComments
-	Lbrace   scan.Token
-	List     []Stmt
-	Rbrace   scan.Token
+	Lbrace scan.Token
+	List   []Stmt
+	Rbrace scan.Token
 }
 
 type Param struct {
@@ -363,6 +360,7 @@ type DeclStmt struct {
 }
 
 type EmptyStmt struct {
+	Comments  *RelComments
 	Semicolon scan.Token
 	Implicit  bool
 }

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Package struct {
-	files   []*File
+	Files   []*File
 	version string // TODO, type.
 }
 
@@ -22,6 +22,8 @@ type File struct {
 	Unresolved []*Ident
 	Src        NamedReader
 }
+
+type Node interface{}
 
 // maybe every node has positional information?
 type Stmt interface{}
@@ -100,7 +102,7 @@ func NewScope(outer *Scope) *Scope {
 type Object struct {
 	Kind ObjKind
 	Name string      // declared name
-	Decl interface{} // corresponding Field, XxxSpec, FuncDecl, LabeledStmt, AssignStmt, Scope; or nil
+	Decl interface{} // corresponding Field, XxxSpec, FuncDef, LabeledStmt, AssignStmt, Scope; or nil
 	Data interface{} // object-specific data; or nil
 	Type interface{} // placeholder for type information; may be nil
 }
@@ -181,9 +183,10 @@ type BasicLit struct {
 }
 
 type BlockStmt struct {
-	Lbrace scan.Token
-	List   []Stmt
-	Rbrace scan.Token
+	Comments *RelComments
+	Lbrace   scan.Token
+	List     []Stmt
+	Rbrace   scan.Token
 }
 
 type Param struct {
@@ -360,7 +363,6 @@ type DeclStmt struct {
 }
 
 type EmptyStmt struct {
-	Comments  *RelComments
 	Semicolon scan.Token
 	Implicit  bool
 }


### PR DESCRIPTION
* Disambiguate between assignments and declarations.
  * New rule: No mixing between old and new variables.
* Make sure all named function definitions are declared in scope.
* Make sure all variable declarations are defined in scope.
* Make sure that declarations precede use.

Updates #2.